### PR TITLE
Add Networked Data Store block with global registry and remote access

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ markdown/systems/block
 markdown/systems/block-info
 markdown/systems/chamber
 markdown/systems/datastore-block
+markdown/systems/networked-datastore-block
 markdown/systems/disk-drive-block
 markdown/systems/display-module-block
 markdown/systems/factory-block

--- a/docs/markdown/io/networking.md
+++ b/docs/markdown/io/networking.md
@@ -70,6 +70,21 @@ Useful for coordination between foreground commands and background scripts on on
 - `receiveModem()`
 - `hasModemMessage()`
 
+## Networked Data Stores
+
+- `getDataStore(name)`
+  Returns a `RemoteDataStore` handle for the named [Networked Data Store](../systems/networked-datastore-block.md),
+  or `nil` if the name is not registered. The handle allows reading and writing
+  data without the owning entity being loaded.
+
+```lua
+local store = net:getDataStore("faction-prices")
+if store then
+    print(store:getValue("iron_ore"))
+    store:set("iron_ore", "200")
+end
+```
+
 ## Discovery helpers
 
 - `getHostnames()`

--- a/docs/markdown/systems/INDEX.md
+++ b/docs/markdown/systems/INDEX.md
@@ -15,6 +15,7 @@ Game systems including blocks, modules, inventories, and specialized mechanics.
 - **block-info.md** - Block information reference
 - **chamber.md** - Reactor chamber wrapper
 - **datastore-block.md** - Per-block shared data store wrapper
+- **networked-datastore-block.md** - Networked data store (entity-independent access)
 - **disk-drive-block.md** - Disk drive block wrapper
 - **password-permission-module.md** - Password-gated permission module wrapper
 - **display-module-block.md** - Display module wrapper

--- a/docs/markdown/systems/networked-datastore-block.md
+++ b/docs/markdown/systems/networked-datastore-block.md
@@ -1,0 +1,153 @@
+# Networked Data Store API
+
+`NetworkedDataStore` is a persistent key-value store that registers itself in a global name registry, allowing any computer to access its data via the network API (`net:getDataStore(name)`) **without the owning entity being loaded**.
+
+Unlike the regular [DataStore](datastore-block.md), access control is configured programmatically rather than through adjacent permission blocks.
+
+## Key differences from DataStore
+
+| Feature | DataStore | Networked Data Store |
+| --- | --- | --- |
+| Access when entity unloaded | No | **Yes** |
+| Access control | Adjacent permission blocks | Configurable via `setAccessLevel()` |
+| Network-accessible | No | **Yes**, via `net:getDataStore(name)` |
+| Requires registration | No | Yes, must call `register(name)` |
+| Data on block destruction | Preserved | **Deleted** |
+
+## Setup (on the entity with the block)
+
+```lua
+-- Wrap the Networked Data Store block
+local nds = peripheral.wrap("networked_data_store")
+
+-- Register with a globally unique name
+nds:register("faction-market-prices")
+
+-- Set access level: "entity", "faction", or "public"
+nds:setAccessLevel("public")
+
+-- Write data
+nds:set("iron_ore", "150")
+nds:set("gold_ore", "500")
+```
+
+## Remote access (from any computer, anywhere)
+
+```lua
+-- Get a handle by name - no entity load required
+local store = net:getDataStore("faction-market-prices")
+
+if store then
+    print(store:getValue("iron_ore"))   -- "150"
+    store:set("iron_ore", "175")        -- write back
+
+    local keys = store:keys()
+    for i = 1, #keys do
+        print(keys[i], store:getValue(keys[i]))
+    end
+end
+```
+
+## Access levels
+
+| Level | Who can access |
+| --- | --- |
+| `"entity"` (default) | Only computers on the **same entity** as the block. Remote access via `net:getDataStore()` is denied. |
+| `"faction"` | Any computer belonging to the **same faction** as the block's owning entity. |
+| `"public"` | **Any** computer, regardless of faction. |
+
+Access level is set via `setAccessLevel()` and can only be changed by a computer on the same entity as the block.
+
+## Block peripheral reference
+
+These methods are available when wrapping the physical block via `peripheral.wrap()`.
+
+### Registration & configuration
+
+- `register(name: String)`
+  Registers this store in the global registry with the given name. Names must be globally unique, 1-64 characters, and contain only letters, digits, hyphens, and underscores. Returns `false` if the name is already taken.
+
+- `unregister()`
+  Removes this store from the global registry and **deletes all its data**. Returns `true` on success.
+
+- `isRegistered()`
+  Returns `true` if this store is currently registered in the global registry.
+
+- `getStoreName()`
+  Returns the registered name, or `nil` if not yet registered.
+
+- `setAccessLevel(level: String)`
+  Sets the access level to `"entity"`, `"faction"`, or `"public"`. Requires the computer to be on the same entity.
+
+- `getAccessLevel()`
+  Returns the current access level as a string.
+
+- `getStoreId()`
+  Returns the persistent UUID backing this store's data.
+
+- `getOwnerFactionId()`
+  Returns the integer faction ID of the entity this block is installed on.
+
+### Data access
+
+- `getValue(key: String)`
+  Returns the value stored at `key`, or `nil` when absent.
+
+- `set(key: String, value: String)`
+  Stores `value` under `key`. Pass `nil` as the value to delete the key.
+
+- `delete(key: String)`
+  Removes `key`. Returns `true` when a key was actually present.
+
+- `has(key: String)`
+  Returns `true` when `key` exists in the store.
+
+- `keys()`
+  Returns a table (array) of all keys in this store.
+
+- `keys(prefix: String)`
+  Returns a table (array) of all keys that begin with `prefix`.
+
+- `size()`
+  Returns the total number of keys currently stored.
+
+## Remote handle reference (`RemoteDataStore`)
+
+These methods are available on the handle returned by `net:getDataStore(name)`.
+
+### Data access
+
+- `getValue(key: String)` - Returns value at `key`, or `nil`.
+- `set(key: String, value: String)` - Stores `value` under `key`.
+- `delete(key: String)` - Removes `key`. Returns `true` if present.
+- `has(key: String)` - Returns `true` if `key` exists.
+- `keys()` - Returns table of all keys.
+- `keys(prefix: String)` - Returns table of keys starting with `prefix`.
+- `size()` - Returns total key count.
+
+### Info
+
+- `getStoreName()` - Returns the registered name.
+- `getAccessLevel()` - Returns the access level string.
+- `getOwnerFactionId()` - Returns the owning faction ID.
+
+## Limits
+
+| Item | Limit |
+| --- | --- |
+| Store name length | 64 characters |
+| Store name characters | Letters, digits, hyphens, underscores |
+| Key length | 256 characters |
+| Value length | 65 536 characters (64 KiB) |
+| Keys per store | 10 000 |
+
+Exceeding any limit raises a Lua error.
+
+## Notes
+
+- **Data is destroyed** when the block is removed or killed. This is intentional - the block is the authority for the data's lifecycle.
+- Names are **case-insensitive** and globally unique across all factions.
+- The store's UUID is assigned when the block is placed and never changes.
+- Data is stored at `<worldData>/datastores/<uuid>.json` (same system as regular DataStore).
+- The global name registry is stored at `<worldData>/networked_datastores.json`.
+- A store with `"entity"` access level **cannot** be accessed remotely via `net:getDataStore()`. Set access to `"faction"` or `"public"` for remote access.

--- a/src/main/java/luamade/LuaMade.java
+++ b/src/main/java/luamade/LuaMade.java
@@ -4,6 +4,7 @@ import api.config.BlockConfig;
 import api.mod.StarMod;
 import luamade.element.ElementRegistry;
 import luamade.lua.peripheral.PeripheralRegistry;
+import luamade.lua.datastore.NetworkedDataStoreRegistry;
 import luamade.lua.datastore.SharedDataStore;
 import luamade.manager.ComputerDataCleanupManager;
 import luamade.manager.ConfigManager;
@@ -36,6 +37,7 @@ public class LuaMade extends StarMod {
 		PeripheralRegistry.registerDefaults();
 		ConfigManager.initialize(this);
 		EventManager.registerEvents(this);
+		NetworkedDataStoreRegistry.load();
 	}
 
 	@Override
@@ -51,6 +53,11 @@ public class LuaMade extends StarMod {
 			SharedDataStore.saveAll();
 		} catch(Exception exception) {
 			logException("Failed to save data store state on disable", exception);
+		}
+		try {
+			NetworkedDataStoreRegistry.saveAll();
+		} catch(Exception exception) {
+			logException("Failed to save networked data store registry on disable", exception);
 		}
 		super.onDisable();
 	}

--- a/src/main/java/luamade/element/ElementRegistry.java
+++ b/src/main/java/luamade/element/ElementRegistry.java
@@ -7,6 +7,7 @@ import luamade.LuaMade;
 import luamade.element.block.Computer;
 import luamade.element.block.DataStore;
 import luamade.element.block.DiskDrive;
+import luamade.element.block.NetworkedDataStore;
 import luamade.element.block.PasswordPermissionModule;
 import luamade.element.block.RemoteAccessPoint;
 import luamade.element.item.Disk;
@@ -23,6 +24,7 @@ public enum ElementRegistry {
 	DISK_DRIVE(new DiskDrive()),
 	REMOTE_ACCESS_POINT(new RemoteAccessPoint()),
 	DATA_STORE(new DataStore()),
+	NETWORKED_DATA_STORE(new NetworkedDataStore()),
 	PASSWORD_PERMISSION_MODULE(new PasswordPermissionModule()),
 	DISK(new Disk()),
 	REMOTE_CONTROL(new RemoteControl());

--- a/src/main/java/luamade/element/block/NetworkedDataStore.java
+++ b/src/main/java/luamade/element/block/NetworkedDataStore.java
@@ -1,0 +1,80 @@
+package luamade.element.block;
+
+import api.config.BlockConfig;
+import api.listener.fastevents.segmentpiece.SegmentPieceKilledListener;
+import api.listener.fastevents.segmentpiece.SegmentPieceRemoveListener;
+import api.utils.element.Blocks;
+import luamade.element.ElementRegistry;
+import luamade.system.module.NetworkedDataStoreModuleContainer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.schema.game.common.controller.ManagedUsableSegmentController;
+import org.schema.game.common.controller.SendableSegmentController;
+import org.schema.game.common.controller.damage.Damager;
+import org.schema.game.common.data.SegmentPiece;
+import org.schema.game.common.data.element.ElementCollection;
+import org.schema.game.common.data.element.ElementKeyMap;
+import org.schema.game.common.data.element.FactoryResource;
+import org.schema.game.common.data.world.Segment;
+
+/**
+ * Element block definition for the Networked Data Store.
+ *
+ * <p>Unlike the regular {@link DataStore}, a Networked Data Store registers
+ * itself in a global name registry so that its data can be accessed by any
+ * computer without the owning entity being loaded.
+ *
+ * <p>When the block is removed or destroyed, its registration and backing data
+ * are deleted.
+ */
+public class NetworkedDataStore extends Block implements SegmentPieceRemoveListener, SegmentPieceKilledListener {
+
+	public NetworkedDataStore() {
+		super("Networked Data Store");
+	}
+
+	@Override
+	public void initData() {
+		super.initData();
+		blockInfo.setDescription("A networked data store. Registers a named key-value store in a global registry accessible by any computer via the network API, even when this entity is unloaded. Data is destroyed when this block is removed.");
+		blockInfo.setInRecipe(true);
+		blockInfo.setShoppable(true);
+		blockInfo.setPrice(ElementKeyMap.getInfo(ElementKeyMap.TEXT_BOX).price * 4);
+		blockInfo.setOrientatable(true);
+		blockInfo.setCanActivate(false);
+		blockInfo.volume = 0.2f;
+	}
+
+	@Override
+	public void postInitData() {
+		BlockConfig.addRecipe(blockInfo, ElementKeyMap.getInfo(ElementKeyMap.TEXT_BOX).getProducedInFactoryType(), (int) ElementKeyMap.getInfo(ElementKeyMap.TEXT_BOX).getFactoryBakeTime(), new FactoryResource(1, ElementKeyMap.TEXT_BOX), new FactoryResource(200, (short) 220));
+	}
+
+	@Override
+	public void initResources() {
+		blockInfo.setBuildIconNum(Blocks.DECORATIVE_SERVER.getInfo().getBuildIconNum());
+		blockInfo.setTextureId(Blocks.DECORATIVE_SERVER.getInfo().getTextureIds());
+	}
+
+	@Override
+	public void onBlockRemove(short type, int segmentSize, byte x, byte y, byte z, byte b3, Segment segment, boolean preserveControl, boolean server) {
+		if(type != ElementRegistry.NETWORKED_DATA_STORE.getId()) return;
+		if(!(segment.getSegmentController() instanceof ManagedUsableSegmentController<?>)) return;
+		long absIndex = ElementCollection.getIndex(x, y, z);
+		ManagedUsableSegmentController<?> controller = (ManagedUsableSegmentController<?>) segment.getSegmentController();
+		NetworkedDataStoreModuleContainer container = NetworkedDataStoreModuleContainer.getContainer(controller.getManagerContainer());
+		if(container != null) {
+			container.removeBlock(absIndex);
+		}
+	}
+
+	@Override
+	public void onBlockKilled(SegmentPiece segmentPiece, SendableSegmentController sendableSegmentController, @Nullable Damager damager, boolean b) {
+		if(segmentPiece == null || segmentPiece.getType() != ElementRegistry.NETWORKED_DATA_STORE.getId()) return;
+		if(!(sendableSegmentController instanceof ManagedUsableSegmentController<?>)) return;
+		ManagedUsableSegmentController<?> controller = (ManagedUsableSegmentController<?>) sendableSegmentController;
+		NetworkedDataStoreModuleContainer container = NetworkedDataStoreModuleContainer.getContainer(controller.getManagerContainer());
+		if(container != null) {
+			container.removeBlock(segmentPiece.getAbsoluteIndex());
+		}
+	}
+}

--- a/src/main/java/luamade/lua/datastore/NetworkedDataStoreRegistry.java
+++ b/src/main/java/luamade/lua/datastore/NetworkedDataStoreRegistry.java
@@ -1,0 +1,219 @@
+package luamade.lua.datastore;
+
+import luamade.LuaMade;
+import luamade.utils.DataUtils;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Global registry that maps user-chosen store names to their backing UUIDs and
+ * access-control metadata. Persisted to {@code <worldData>/networked_datastores.json}.
+ *
+ * <p>This registry is loaded once at server start and kept in memory. It allows
+ * any computer to resolve a Networked Data Store by name without the owning
+ * entity being loaded.
+ *
+ * <p>Names are globally unique and case-insensitive.
+ */
+public final class NetworkedDataStoreRegistry {
+
+	/**
+	 * Access levels that can be configured on a networked data store.
+	 */
+	public enum AccessLevel {
+		/** Only computers on the same entity can access. */
+		ENTITY,
+		/** Only computers belonging to the same faction can access. */
+		FACTION,
+		/** Any computer can access. */
+		PUBLIC;
+
+		public static AccessLevel fromString(String s) {
+			if(s == null) return ENTITY;
+			switch(s.toLowerCase()) {
+				case "public": return PUBLIC;
+				case "faction": return FACTION;
+				default: return ENTITY;
+			}
+		}
+	}
+
+	/**
+	 * Metadata for a single registered networked data store.
+	 */
+	public static final class StoreEntry {
+		private final String uuid;
+		private final String name;
+		private volatile int ownerFactionId;
+		private volatile AccessLevel accessLevel;
+
+		public StoreEntry(String uuid, String name, int ownerFactionId, AccessLevel accessLevel) {
+			this.uuid = uuid;
+			this.name = name;
+			this.ownerFactionId = ownerFactionId;
+			this.accessLevel = accessLevel;
+		}
+
+		public String getUuid() {
+			return uuid;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getOwnerFactionId() {
+			return ownerFactionId;
+		}
+
+		public void setOwnerFactionId(int ownerFactionId) {
+			this.ownerFactionId = ownerFactionId;
+		}
+
+		public AccessLevel getAccessLevel() {
+			return accessLevel;
+		}
+
+		public void setAccessLevel(AccessLevel accessLevel) {
+			this.accessLevel = accessLevel;
+		}
+	}
+
+	/** Normalized name → store entry. */
+	private static final ConcurrentHashMap<String, StoreEntry> entries = new ConcurrentHashMap<>();
+
+	private static final Object fileLock = new Object();
+
+	private NetworkedDataStoreRegistry() {
+	}
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Registers a new networked data store. Returns {@code false} if the name
+	 * is already taken.
+	 */
+	public static boolean register(String name, String uuid, int ownerFactionId, AccessLevel accessLevel) {
+		if(name == null || name.isEmpty() || uuid == null || uuid.isEmpty()) return false;
+		String key = normalize(name);
+		StoreEntry entry = new StoreEntry(uuid, name, ownerFactionId, accessLevel);
+		if(entries.putIfAbsent(key, entry) != null) {
+			return false;
+		}
+		persist();
+		return true;
+	}
+
+	/**
+	 * Removes a networked data store registration and deletes its backing data.
+	 */
+	public static boolean unregister(String name) {
+		if(name == null) return false;
+		StoreEntry removed = entries.remove(normalize(name));
+		if(removed != null) {
+			SharedDataStore.deleteStore(removed.getUuid());
+			persist();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Resolves a store name to its entry. Returns {@code null} if not found.
+	 */
+	public static StoreEntry resolve(String name) {
+		if(name == null) return null;
+		return entries.get(normalize(name));
+	}
+
+	/**
+	 * Checks if a name is already registered.
+	 */
+	public static boolean isNameTaken(String name) {
+		if(name == null) return false;
+		return entries.containsKey(normalize(name));
+	}
+
+	/**
+	 * Loads the registry from disk. Called once at server start.
+	 */
+	public static void load() {
+		entries.clear();
+		File file = registryFile();
+		if(file == null || !file.exists()) return;
+		try {
+			String json = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+			JSONObject root = new JSONObject(json);
+			Iterator<String> it = root.keys();
+			while(it.hasNext()) {
+				String key = it.next();
+				JSONObject obj = root.optJSONObject(key);
+				if(obj == null) continue;
+				String uuid = obj.optString("uuid", null);
+				String name = obj.optString("name", key);
+				int factionId = obj.optInt("ownerFactionId", 0);
+				AccessLevel access = AccessLevel.fromString(obj.optString("accessLevel", "entity"));
+				if(uuid != null && !uuid.isEmpty()) {
+					entries.put(normalize(name), new StoreEntry(uuid, name, factionId, access));
+				}
+			}
+			LuaMade.getInstance().logDebug("Loaded " + entries.size() + " networked data store registrations");
+		} catch(Exception ex) {
+			LuaMade.getInstance().logWarning("Failed to load networked data store registry: " + ex.getMessage());
+		}
+	}
+
+	/**
+	 * Saves the registry to disk. Called on server shutdown.
+	 */
+	public static void saveAll() {
+		persist();
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal
+	// -------------------------------------------------------------------------
+
+	private static void persist() {
+		File file = registryFile();
+		if(file == null) return;
+		synchronized(fileLock) {
+			try {
+				File parent = file.getParentFile();
+				if(parent != null && !parent.exists()) {
+					parent.mkdirs();
+				}
+				JSONObject root = new JSONObject();
+				for(StoreEntry entry : entries.values()) {
+					JSONObject obj = new JSONObject();
+					obj.put("uuid", entry.getUuid());
+					obj.put("name", entry.getName());
+					obj.put("ownerFactionId", entry.getOwnerFactionId());
+					obj.put("accessLevel", entry.getAccessLevel().name().toLowerCase());
+					root.put(normalize(entry.getName()), obj);
+				}
+				Files.write(file.toPath(), root.toString(2).getBytes(StandardCharsets.UTF_8));
+			} catch(IOException ex) {
+				LuaMade.getInstance().logWarning("Failed to persist networked data store registry: " + ex.getMessage());
+			}
+		}
+	}
+
+	private static File registryFile() {
+		String worldDataPath = DataUtils.getWorldDataPath();
+		if(worldDataPath == null || worldDataPath.trim().isEmpty()) return null;
+		return new File(worldDataPath, "networked_datastores.json");
+	}
+
+	private static String normalize(String name) {
+		return name.toLowerCase().trim();
+	}
+}

--- a/src/main/java/luamade/lua/datastore/RemoteDataStoreHandle.java
+++ b/src/main/java/luamade/lua/datastore/RemoteDataStoreHandle.java
@@ -1,0 +1,138 @@
+package luamade.lua.datastore;
+
+import luamade.lua.datastore.NetworkedDataStoreRegistry.AccessLevel;
+import luamade.lua.datastore.NetworkedDataStoreRegistry.StoreEntry;
+import luamade.luawrap.LuaMadeCallable;
+import luamade.luawrap.LuaMadeClass;
+import luamade.luawrap.LuaMadeUserdata;
+import luamade.system.module.ComputerModule;
+import org.luaj.vm2.LuaError;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+
+import java.util.List;
+
+/**
+ * A lightweight remote handle to a Networked Data Store, resolved by name
+ * through the global registry. Does not require the owning entity to be loaded.
+ *
+ * <p>Returned by {@link luamade.lua.networking.NetworkInterface#getDataStore}.
+ * Provides read/write access subject to the store's configured access level.
+ */
+@LuaMadeClass("RemoteDataStore")
+public class RemoteDataStoreHandle extends LuaMadeUserdata {
+
+	private final String storeName;
+	private final ComputerModule module;
+
+	public RemoteDataStoreHandle(String storeName, ComputerModule module) {
+		this.storeName = storeName;
+		this.module = module;
+	}
+
+	// -------------------------------------------------------------------------
+	// Data access
+	// -------------------------------------------------------------------------
+
+	@LuaMadeCallable
+	public String getValue(String key) {
+		checkAccess();
+		return SharedDataStore.get(resolveUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public void set(String key, String value) {
+		checkAccess();
+		SharedDataStore.set(resolveUuid(), key, value);
+	}
+
+	@LuaMadeCallable
+	public Boolean delete(String key) {
+		checkAccess();
+		return SharedDataStore.delete(resolveUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public Boolean has(String key) {
+		checkAccess();
+		return SharedDataStore.containsKey(resolveUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public LuaTable keys() {
+		checkAccess();
+		return toTable(SharedDataStore.keys(resolveUuid(), null));
+	}
+
+	@LuaMadeCallable
+	public LuaTable keys(String prefix) {
+		checkAccess();
+		return toTable(SharedDataStore.keys(resolveUuid(), prefix));
+	}
+
+	@LuaMadeCallable
+	public Integer size() {
+		checkAccess();
+		return SharedDataStore.size(resolveUuid());
+	}
+
+	// -------------------------------------------------------------------------
+	// Info
+	// -------------------------------------------------------------------------
+
+	@LuaMadeCallable
+	public String getStoreName() {
+		return storeName;
+	}
+
+	@LuaMadeCallable
+	public String getAccessLevel() {
+		StoreEntry entry = resolveEntry();
+		return entry.getAccessLevel().name().toLowerCase();
+	}
+
+	@LuaMadeCallable
+	public Integer getOwnerFactionId() {
+		StoreEntry entry = resolveEntry();
+		return entry.getOwnerFactionId();
+	}
+
+	// -------------------------------------------------------------------------
+	// Internals
+	// -------------------------------------------------------------------------
+
+	private StoreEntry resolveEntry() {
+		StoreEntry entry = NetworkedDataStoreRegistry.resolve(storeName);
+		if(entry == null) {
+			throw new LuaError("Networked data store '" + storeName + "' is not registered");
+		}
+		return entry;
+	}
+
+	private String resolveUuid() {
+		return resolveEntry().getUuid();
+	}
+
+	private void checkAccess() {
+		StoreEntry entry = resolveEntry();
+		switch(entry.getAccessLevel()) {
+			case PUBLIC:
+				return;
+			case FACTION:
+				int computerFaction = module.getSegmentPiece().getSegmentController().getFactionId();
+				if(computerFaction != 0 && computerFaction == entry.getOwnerFactionId()) return;
+				throw new LuaError("Access denied: computer is not in the same faction as networked data store '" + storeName + "'");
+			case ENTITY:
+			default:
+				throw new LuaError("Access denied: networked data store '" + storeName + "' has entity-level access and can only be accessed locally");
+		}
+	}
+
+	private static LuaTable toTable(List<String> list) {
+		LuaTable table = new LuaTable();
+		for(int i = 0; i < list.size(); i++) {
+			table.rawset(i + 1, LuaValue.valueOf(list.get(i)));
+		}
+		return table;
+	}
+}

--- a/src/main/java/luamade/lua/datastore/SharedDataStore.java
+++ b/src/main/java/luamade/lua/datastore/SharedDataStore.java
@@ -121,6 +121,19 @@ public final class SharedDataStore {
 		}
 	}
 
+	/**
+	 * Removes a store entirely — deletes the in-memory map and the backing
+	 * JSON file on disk. Used when a Networked Data Store block is destroyed.
+	 */
+	public static void deleteStore(String storeUuid) {
+		stores.remove(storeUuid);
+		storeLocks.remove(storeUuid);
+		File file = storeFile(storeUuid);
+		if(file != null && file.exists()) {
+			file.delete();
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Internal helpers
 	// -------------------------------------------------------------------------

--- a/src/main/java/luamade/lua/element/block/NetworkedDataStoreBlock.java
+++ b/src/main/java/luamade/lua/element/block/NetworkedDataStoreBlock.java
@@ -1,0 +1,296 @@
+package luamade.lua.element.block;
+
+import luamade.element.ElementRegistry;
+import luamade.lua.datastore.NetworkedDataStoreRegistry;
+import luamade.lua.datastore.NetworkedDataStoreRegistry.AccessLevel;
+import luamade.lua.datastore.NetworkedDataStoreRegistry.StoreEntry;
+import luamade.lua.datastore.SharedDataStore;
+import luamade.luawrap.LuaMadeCallable;
+import luamade.luawrap.LuaMadeClass;
+import luamade.system.module.ComputerModule;
+import luamade.system.module.NetworkedDataStoreModuleContainer;
+import org.luaj.vm2.LuaError;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+import org.schema.game.common.controller.ManagedUsableSegmentController;
+import org.schema.game.common.data.SegmentPiece;
+
+import java.util.List;
+
+/**
+ * Lua-facing wrapper for a Networked Data Store block (peripheral access).
+ *
+ * <p>This wrapper is used when a computer has direct access to the physical
+ * block (same entity or adjacent). It provides the full API including
+ * registration, naming, and access-level configuration.
+ *
+ * <h2>Access control</h2>
+ * Access is controlled by a configurable access level stored in the global
+ * registry rather than by adjacent permission blocks:
+ * <ul>
+ *   <li>{@code "entity"} — only computers on the same entity (default).</li>
+ *   <li>{@code "faction"} — any computer belonging to the same faction.</li>
+ *   <li>{@code "public"} — any computer.</li>
+ * </ul>
+ */
+@LuaMadeClass("NetworkedDataStore")
+public class NetworkedDataStoreBlock extends Block {
+
+	private final ComputerModule module;
+
+	public NetworkedDataStoreBlock(SegmentPiece piece, ComputerModule module) {
+		super(piece, module);
+		this.module = module;
+	}
+
+	// -------------------------------------------------------------------------
+	// Registration & configuration (requires physical access)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Registers this block's data store with the given globally-unique name.
+	 * Returns {@code false} if the name is already taken or if the store is
+	 * already registered.
+	 */
+	@LuaMadeCallable
+	public Boolean register(String name) {
+		checkSameEntity();
+		if(name == null || name.isEmpty()) {
+			throw new LuaError("Name must not be empty");
+		}
+		if(name.length() > 64) {
+			throw new LuaError("Name must be 64 characters or fewer");
+		}
+		if(!name.matches("[a-zA-Z0-9_\\-]+")) {
+			throw new LuaError("Name may only contain letters, digits, hyphens, and underscores");
+		}
+
+		NetworkedDataStoreModuleContainer container = getContainer();
+		long absIndex = getSegmentPiece().getAbsoluteIndex();
+		String uuid = container.getOrAssignUuid(absIndex);
+		int factionId = getSegmentPiece().getSegmentController().getFactionId();
+
+		// Check if already registered under a different name
+		String currentName = container.getName(absIndex);
+		if(currentName != null && !currentName.isEmpty()) {
+			throw new LuaError("This store is already registered as '" + currentName + "'. Unregister it first.");
+		}
+
+		boolean success = NetworkedDataStoreRegistry.register(name, uuid, factionId, AccessLevel.ENTITY);
+		if(success) {
+			container.setName(absIndex, name);
+		}
+		return success;
+	}
+
+	/**
+	 * Unregisters this block's data store from the global registry and
+	 * deletes all its data.
+	 */
+	@LuaMadeCallable
+	public Boolean unregister() {
+		checkSameEntity();
+		NetworkedDataStoreModuleContainer container = getContainer();
+		long absIndex = getSegmentPiece().getAbsoluteIndex();
+		String name = container.getName(absIndex);
+		if(name == null || name.isEmpty()) return false;
+		boolean success = NetworkedDataStoreRegistry.unregister(name);
+		if(success) {
+			container.setName(absIndex, null);
+		}
+		return success;
+	}
+
+	/**
+	 * Returns the registered name, or {@code nil} if not yet registered.
+	 */
+	@LuaMadeCallable
+	public String getStoreName() {
+		NetworkedDataStoreModuleContainer container = getContainer();
+		return container.getName(getSegmentPiece().getAbsoluteIndex());
+	}
+
+	/**
+	 * Returns the persistent UUID backing this block's data.
+	 */
+	@LuaMadeCallable
+	public String getStoreId() {
+		return storeUuid();
+	}
+
+	/**
+	 * Sets the access level for this store. Must be {@code "entity"},
+	 * {@code "faction"}, or {@code "public"}.
+	 */
+	@LuaMadeCallable
+	public void setAccessLevel(String level) {
+		checkSameEntity();
+		String name = getRegisteredName();
+		StoreEntry entry = NetworkedDataStoreRegistry.resolve(name);
+		if(entry == null) throw new LuaError("Store is not registered");
+		AccessLevel accessLevel = AccessLevel.fromString(level);
+		entry.setAccessLevel(accessLevel);
+		NetworkedDataStoreRegistry.saveAll();
+	}
+
+	/**
+	 * Returns the current access level: {@code "entity"}, {@code "faction"},
+	 * or {@code "public"}.
+	 */
+	@LuaMadeCallable
+	public String getAccessLevel() {
+		String name = getContainerName();
+		if(name == null || name.isEmpty()) return "entity";
+		StoreEntry entry = NetworkedDataStoreRegistry.resolve(name);
+		if(entry == null) return "entity";
+		return entry.getAccessLevel().name().toLowerCase();
+	}
+
+	/**
+	 * Returns the faction ID of the entity this block is installed on.
+	 */
+	@LuaMadeCallable
+	public Integer getOwnerFactionId() {
+		return getSegmentPiece().getSegmentController().getFactionId();
+	}
+
+	/**
+	 * Returns whether this store is currently registered in the global registry.
+	 */
+	@LuaMadeCallable
+	public Boolean isRegistered() {
+		String name = getContainerName();
+		return name != null && !name.isEmpty() && NetworkedDataStoreRegistry.isNameTaken(name);
+	}
+
+	// -------------------------------------------------------------------------
+	// Data access (same API as DataStoreBlock)
+	// -------------------------------------------------------------------------
+
+	@LuaMadeCallable
+	public String getValue(String key) {
+		checkAccess();
+		return SharedDataStore.get(storeUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public void set(String key, String value) {
+		checkAccess();
+		SharedDataStore.set(storeUuid(), key, value);
+	}
+
+	@LuaMadeCallable
+	public Boolean delete(String key) {
+		checkAccess();
+		return SharedDataStore.delete(storeUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public Boolean has(String key) {
+		checkAccess();
+		return SharedDataStore.containsKey(storeUuid(), key);
+	}
+
+	@LuaMadeCallable
+	public LuaTable keys() {
+		checkAccess();
+		return toTable(SharedDataStore.keys(storeUuid(), null));
+	}
+
+	@LuaMadeCallable
+	public LuaTable keys(String prefix) {
+		checkAccess();
+		return toTable(SharedDataStore.keys(storeUuid(), prefix));
+	}
+
+	@LuaMadeCallable
+	public Integer size() {
+		checkAccess();
+		return SharedDataStore.size(storeUuid());
+	}
+
+	// -------------------------------------------------------------------------
+	// Internals
+	// -------------------------------------------------------------------------
+
+	private String storeUuid() {
+		NetworkedDataStoreModuleContainer container = getContainer();
+		return container.getOrAssignUuid(getSegmentPiece().getAbsoluteIndex());
+	}
+
+	private NetworkedDataStoreModuleContainer getContainer() {
+		SegmentPiece piece = getSegmentPiece();
+		if(!(piece.getSegmentController() instanceof ManagedUsableSegmentController<?>)) {
+			throw new LuaError("Networked data store is not available on this structure type");
+		}
+		ManagedUsableSegmentController<?> controller = (ManagedUsableSegmentController<?>) piece.getSegmentController();
+		NetworkedDataStoreModuleContainer container = NetworkedDataStoreModuleContainer.getContainer(controller.getManagerContainer());
+		if(container == null) {
+			throw new LuaError("Networked data store module is not initialized");
+		}
+		return container;
+	}
+
+	private String getContainerName() {
+		try {
+			NetworkedDataStoreModuleContainer container = getContainer();
+			return container.getName(getSegmentPiece().getAbsoluteIndex());
+		} catch(LuaError e) {
+			return null;
+		}
+	}
+
+	private String getRegisteredName() {
+		String name = getContainerName();
+		if(name == null || name.isEmpty()) {
+			throw new LuaError("This store is not registered. Call register(name) first.");
+		}
+		return name;
+	}
+
+	/**
+	 * Checks that the calling computer is on the same entity as this block.
+	 * Used for configuration operations that require physical ownership.
+	 */
+	private void checkSameEntity() {
+		if(getSegmentPiece().getSegmentController() != module.getSegmentPiece().getSegmentController()) {
+			throw new LuaError("This operation requires the computer to be on the same entity as the Networked Data Store");
+		}
+	}
+
+	/**
+	 * Enforces the access level configured in the registry.
+	 */
+	private void checkAccess() {
+		String name = getContainerName();
+		if(name == null || name.isEmpty()) {
+			// Not registered yet — same-entity only
+			checkSameEntity();
+			return;
+		}
+		StoreEntry entry = NetworkedDataStoreRegistry.resolve(name);
+		if(entry == null) {
+			checkSameEntity();
+			return;
+		}
+		switch(entry.getAccessLevel()) {
+			case PUBLIC:
+				return;
+			case FACTION:
+				int computerFaction = module.getSegmentPiece().getSegmentController().getFactionId();
+				if(computerFaction != 0 && computerFaction == entry.getOwnerFactionId()) return;
+				throw new LuaError("Access denied: computer is not in the same faction as this networked data store");
+			case ENTITY:
+			default:
+				checkSameEntity();
+		}
+	}
+
+	private static LuaTable toTable(List<String> list) {
+		LuaTable table = new LuaTable();
+		for(int i = 0; i < list.size(); i++) {
+			table.rawset(i + 1, LuaValue.valueOf(list.get(i)));
+		}
+		return table;
+	}
+}

--- a/src/main/java/luamade/lua/networking/NetworkInterface.java
+++ b/src/main/java/luamade/lua/networking/NetworkInterface.java
@@ -1,5 +1,7 @@
 package luamade.lua.networking;
 
+import luamade.lua.datastore.NetworkedDataStoreRegistry;
+import luamade.lua.datastore.RemoteDataStoreHandle;
 import luamade.luawrap.LuaMadeCallable;
 import luamade.luawrap.LuaMadeUserdata;
 import luamade.system.module.ComputerModule;
@@ -420,6 +422,18 @@ public class NetworkInterface extends LuaMadeUserdata {
 	@LuaMadeCallable
 	public boolean ping(String targetHostname) {
 		return networkInterfaces.containsKey(targetHostname);
+	}
+
+	/**
+	 * Returns a remote handle to a Networked Data Store by its registered name.
+	 * The handle allows reading and writing data without the owning entity being
+	 * loaded. Returns {@code nil} if the name is not registered.
+	 */
+	@LuaMadeCallable
+	public RemoteDataStoreHandle getDataStore(String name) {
+		if(name == null || name.isEmpty()) return null;
+		if(!NetworkedDataStoreRegistry.isNameTaken(name)) return null;
+		return new RemoteDataStoreHandle(name, module);
 	}
 
 	private boolean subscribeToChannel(Map<String, Channel> registry, String channelName, String password) {

--- a/src/main/java/luamade/lua/peripheral/PeripheralRegistry.java
+++ b/src/main/java/luamade/lua/peripheral/PeripheralRegistry.java
@@ -182,6 +182,23 @@ public class PeripheralRegistry {
 		register(new PeripheralProvider() {
 			@Override
 			public String[] getTypeNames() {
+				return new String[]{"networkeddatastore", "networked_data_store", "networked-data-store", "netdatastore", "net_data_store"};
+			}
+
+			@Override
+			public boolean canWrap(SegmentPiece piece) {
+				return piece.getType() == ElementRegistry.NETWORKED_DATA_STORE.getId();
+			}
+
+			@Override
+			public Block wrap(SegmentPiece piece, ComputerModule module) {
+				return new NetworkedDataStoreBlock(piece, module);
+			}
+		});
+
+		register(new PeripheralProvider() {
+			@Override
+			public String[] getTypeNames() {
 				return new String[]{"inventory"};
 			}
 

--- a/src/main/java/luamade/system/module/NetworkedDataStoreModuleContainer.java
+++ b/src/main/java/luamade/system/module/NetworkedDataStoreModuleContainer.java
@@ -1,0 +1,160 @@
+package luamade.system.module;
+
+import api.network.PacketReadBuffer;
+import api.network.PacketWriteBuffer;
+import api.utils.game.module.util.SystemModule;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import luamade.element.ElementRegistry;
+import luamade.lua.datastore.NetworkedDataStoreRegistry;
+import org.schema.game.common.controller.SegmentController;
+import org.schema.game.common.controller.elements.ManagerContainer;
+import org.schema.schine.graphicsengine.core.Timer;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Per-entity module that assigns a persistent UUID and tracks the registered
+ * name for each Networked Data Store block on the entity.
+ *
+ * <p>The UUID is used as the backing key in {@link luamade.lua.datastore.SharedDataStore}.
+ * The name is registered in {@link NetworkedDataStoreRegistry} for global resolution.
+ *
+ * <p>Format: {@code VERSION(1) | count(int) | [abs(long) uuid(String) name(String)] * count}
+ */
+public class NetworkedDataStoreModuleContainer extends SystemModule {
+
+	private static final byte VERSION = 1;
+
+	/** abs block index → UUID */
+	private final Long2ObjectOpenHashMap<String> blockUuids = new Long2ObjectOpenHashMap<>();
+	/** abs block index → registered name (may be empty if not yet named) */
+	private final Long2ObjectOpenHashMap<String> blockNames = new Long2ObjectOpenHashMap<>();
+
+	public NetworkedDataStoreModuleContainer(SegmentController ship, ManagerContainer<?> managerContainer) {
+		super(ship, managerContainer, luamade.LuaMade.getInstance(), ElementRegistry.NETWORKED_DATA_STORE.getId());
+	}
+
+	public static NetworkedDataStoreModuleContainer getContainer(ManagerContainer<?> managerContainer) {
+		if(managerContainer.getModMCModule(ElementRegistry.NETWORKED_DATA_STORE.getId()) instanceof NetworkedDataStoreModuleContainer) {
+			return (NetworkedDataStoreModuleContainer) managerContainer.getModMCModule(ElementRegistry.NETWORKED_DATA_STORE.getId());
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the persistent UUID for the block at {@code absIndex},
+	 * creating one if it does not yet exist.
+	 */
+	public String getOrAssignUuid(long absIndex) {
+		String uuid = blockUuids.get(absIndex);
+		if(uuid == null) {
+			uuid = UUID.randomUUID().toString();
+			blockUuids.put(absIndex, uuid);
+			flagUpdatedData();
+		}
+		return uuid;
+	}
+
+	public String getUuid(long absIndex) {
+		return blockUuids.get(absIndex);
+	}
+
+	/**
+	 * Returns the registered name for the block, or {@code null} if not named.
+	 */
+	public String getName(long absIndex) {
+		return blockNames.get(absIndex);
+	}
+
+	/**
+	 * Sets the registered name for a block. Updates internal tracking only;
+	 * the caller is responsible for registry operations.
+	 */
+	public void setName(long absIndex, String name) {
+		if(name == null || name.isEmpty()) {
+			blockNames.remove(absIndex);
+		} else {
+			blockNames.put(absIndex, name);
+		}
+		flagUpdatedData();
+	}
+
+	/**
+	 * Removes a block, unregistering its name from the global registry
+	 * (which also deletes the backing data).
+	 */
+	public void removeBlock(long absIndex) {
+		String name = blockNames.remove(absIndex);
+		blockUuids.remove(absIndex);
+		if(name != null && !name.isEmpty()) {
+			NetworkedDataStoreRegistry.unregister(name);
+		}
+		flagUpdatedData();
+	}
+
+	// -------------------------------------------------------------------------
+	// SystemModule boilerplate
+	// -------------------------------------------------------------------------
+
+	@Override
+	public void handlePlace(long abs, byte orientation) {
+		getOrAssignUuid(abs);
+	}
+
+	@Override
+	public void handleRemove(long abs) {
+		removeBlock(abs);
+	}
+
+	@Override
+	public double getPowerConsumedPerSecondResting() {
+		return 0;
+	}
+
+	@Override
+	public double getPowerConsumedPerSecondCharging() {
+		return 0;
+	}
+
+	@Override
+	public String getName() {
+		return "Networked Data Store";
+	}
+
+	@Override
+	public void handle(Timer timer) {
+	}
+
+	@Override
+	public void onTagSerialize(PacketWriteBuffer buffer) throws IOException {
+		buffer.writeByte(VERSION);
+		buffer.writeInt(blockUuids.size());
+		for(long abs : blockUuids.keySet().toLongArray()) {
+			buffer.writeLong(abs);
+			buffer.writeString(blockUuids.get(abs));
+			String name = blockNames.get(abs);
+			buffer.writeString(name != null ? name : "");
+		}
+	}
+
+	@Override
+	public void onTagDeserialize(PacketReadBuffer buffer) throws IOException {
+		blockUuids.clear();
+		blockNames.clear();
+		byte version = buffer.readByte();
+		if(version != VERSION) return;
+		int count = buffer.readInt();
+		for(int i = 0; i < count; i++) {
+			long abs = buffer.readLong();
+			String uuid = buffer.readString();
+			String name = buffer.readString();
+			if(uuid != null && !uuid.isEmpty()) {
+				blockUuids.put(abs, uuid);
+				if(name != null && !name.isEmpty()) {
+					blockNames.put(abs, name);
+				}
+			}
+		}
+	}
+}

--- a/src/main/resources/docs/docs.index
+++ b/src/main/resources/docs/docs.index
@@ -31,6 +31,7 @@ systems/block.md
 systems/chamber.md
 systems/channels.md
 systems/datastore-block.md
+systems/networked-datastore-block.md
 systems/disk-drive-block.md
 systems/display-module-block.md
 systems/factory-block.md

--- a/src/main/resources/docs/io/networking.md
+++ b/src/main/resources/docs/io/networking.md
@@ -70,6 +70,21 @@ Useful for coordination between foreground commands and background scripts on on
 - `receiveModem()`
 - `hasModemMessage()`
 
+## Networked Data Stores
+
+- `getDataStore(name)`
+  Returns a `RemoteDataStore` handle for the named [Networked Data Store](../systems/networked-datastore-block.md),
+  or `nil` if the name is not registered. The handle allows reading and writing
+  data without the owning entity being loaded.
+
+```lua
+local store = net:getDataStore("faction-prices")
+if store then
+    print(store:getValue("iron_ore"))
+    store:set("iron_ore", "200")
+end
+```
+
 ## Discovery helpers
 
 - `getHostnames()`

--- a/src/main/resources/docs/systems/INDEX.md
+++ b/src/main/resources/docs/systems/INDEX.md
@@ -15,6 +15,7 @@ Game systems including blocks, modules, inventories, and specialized mechanics.
 - **block-info.md** - Block information reference
 - **chamber.md** - Reactor chamber wrapper
 - **datastore-block.md** - Per-block shared data store wrapper
+- **networked-datastore-block.md** - Networked data store (entity-independent access)
 - **disk-drive-block.md** - Disk drive block wrapper
 - **password-permission-module.md** - Password-gated permission module wrapper
 - **display-module-block.md** - Display module wrapper

--- a/src/main/resources/docs/systems/networked-datastore-block.md
+++ b/src/main/resources/docs/systems/networked-datastore-block.md
@@ -1,0 +1,153 @@
+# Networked Data Store API
+
+`NetworkedDataStore` is a persistent key-value store that registers itself in a global name registry, allowing any computer to access its data via the network API (`net:getDataStore(name)`) **without the owning entity being loaded**.
+
+Unlike the regular [DataStore](datastore-block.md), access control is configured programmatically rather than through adjacent permission blocks.
+
+## Key differences from DataStore
+
+| Feature | DataStore | Networked Data Store |
+| --- | --- | --- |
+| Access when entity unloaded | No | **Yes** |
+| Access control | Adjacent permission blocks | Configurable via `setAccessLevel()` |
+| Network-accessible | No | **Yes**, via `net:getDataStore(name)` |
+| Requires registration | No | Yes, must call `register(name)` |
+| Data on block destruction | Preserved | **Deleted** |
+
+## Setup (on the entity with the block)
+
+```lua
+-- Wrap the Networked Data Store block
+local nds = peripheral.wrap("networked_data_store")
+
+-- Register with a globally unique name
+nds:register("faction-market-prices")
+
+-- Set access level: "entity", "faction", or "public"
+nds:setAccessLevel("public")
+
+-- Write data
+nds:set("iron_ore", "150")
+nds:set("gold_ore", "500")
+```
+
+## Remote access (from any computer, anywhere)
+
+```lua
+-- Get a handle by name - no entity load required
+local store = net:getDataStore("faction-market-prices")
+
+if store then
+    print(store:getValue("iron_ore"))   -- "150"
+    store:set("iron_ore", "175")        -- write back
+
+    local keys = store:keys()
+    for i = 1, #keys do
+        print(keys[i], store:getValue(keys[i]))
+    end
+end
+```
+
+## Access levels
+
+| Level | Who can access |
+| --- | --- |
+| `"entity"` (default) | Only computers on the **same entity** as the block. Remote access via `net:getDataStore()` is denied. |
+| `"faction"` | Any computer belonging to the **same faction** as the block's owning entity. |
+| `"public"` | **Any** computer, regardless of faction. |
+
+Access level is set via `setAccessLevel()` and can only be changed by a computer on the same entity as the block.
+
+## Block peripheral reference
+
+These methods are available when wrapping the physical block via `peripheral.wrap()`.
+
+### Registration & configuration
+
+- `register(name: String)`
+  Registers this store in the global registry with the given name. Names must be globally unique, 1-64 characters, and contain only letters, digits, hyphens, and underscores. Returns `false` if the name is already taken.
+
+- `unregister()`
+  Removes this store from the global registry and **deletes all its data**. Returns `true` on success.
+
+- `isRegistered()`
+  Returns `true` if this store is currently registered in the global registry.
+
+- `getStoreName()`
+  Returns the registered name, or `nil` if not yet registered.
+
+- `setAccessLevel(level: String)`
+  Sets the access level to `"entity"`, `"faction"`, or `"public"`. Requires the computer to be on the same entity.
+
+- `getAccessLevel()`
+  Returns the current access level as a string.
+
+- `getStoreId()`
+  Returns the persistent UUID backing this store's data.
+
+- `getOwnerFactionId()`
+  Returns the integer faction ID of the entity this block is installed on.
+
+### Data access
+
+- `getValue(key: String)`
+  Returns the value stored at `key`, or `nil` when absent.
+
+- `set(key: String, value: String)`
+  Stores `value` under `key`. Pass `nil` as the value to delete the key.
+
+- `delete(key: String)`
+  Removes `key`. Returns `true` when a key was actually present.
+
+- `has(key: String)`
+  Returns `true` when `key` exists in the store.
+
+- `keys()`
+  Returns a table (array) of all keys in this store.
+
+- `keys(prefix: String)`
+  Returns a table (array) of all keys that begin with `prefix`.
+
+- `size()`
+  Returns the total number of keys currently stored.
+
+## Remote handle reference (`RemoteDataStore`)
+
+These methods are available on the handle returned by `net:getDataStore(name)`.
+
+### Data access
+
+- `getValue(key: String)` - Returns value at `key`, or `nil`.
+- `set(key: String, value: String)` - Stores `value` under `key`.
+- `delete(key: String)` - Removes `key`. Returns `true` if present.
+- `has(key: String)` - Returns `true` if `key` exists.
+- `keys()` - Returns table of all keys.
+- `keys(prefix: String)` - Returns table of keys starting with `prefix`.
+- `size()` - Returns total key count.
+
+### Info
+
+- `getStoreName()` - Returns the registered name.
+- `getAccessLevel()` - Returns the access level string.
+- `getOwnerFactionId()` - Returns the owning faction ID.
+
+## Limits
+
+| Item | Limit |
+| --- | --- |
+| Store name length | 64 characters |
+| Store name characters | Letters, digits, hyphens, underscores |
+| Key length | 256 characters |
+| Value length | 65 536 characters (64 KiB) |
+| Keys per store | 10 000 |
+
+Exceeding any limit raises a Lua error.
+
+## Notes
+
+- **Data is destroyed** when the block is removed or killed. This is intentional - the block is the authority for the data's lifecycle.
+- Names are **case-insensitive** and globally unique across all factions.
+- The store's UUID is assigned when the block is placed and never changes.
+- Data is stored at `<worldData>/datastores/<uuid>.json` (same system as regular DataStore).
+- The global name registry is stored at `<worldData>/networked_datastores.json`.
+- A store with `"entity"` access level **cannot** be accessed remotely via `net:getDataStore()`. Set access to `"faction"` or `"public"` for remote access.


### PR DESCRIPTION
## Summary

Introduces a new **Networked Data Store** block that extends the existing DataStore functionality with global name registration and remote access capabilities. Unlike the regular DataStore, networked stores can be accessed by any computer via the network API without requiring the owning entity to be loaded.

## Key Changes

- **New Block Element**: `NetworkedDataStore` block that registers itself in a global name registry for persistent, network-accessible data storage
- **Global Registry**: `NetworkedDataStoreRegistry` manages globally-unique store names, UUIDs, and access-level metadata, persisted to `networked_datastores.json`
- **Per-Entity Module**: `NetworkedDataStoreModuleContainer` tracks UUID and registration name for each block on an entity, with automatic cleanup on block removal
- **Lua Peripheral Wrapper**: `NetworkedDataStoreBlock` provides the full API including registration, naming, access-level configuration, and data operations
- **Remote Handle**: `RemoteDataStoreHandle` allows computers to access registered stores by name without entity load, subject to access-level restrictions
- **Network Integration**: Added `getDataStore(name)` method to `NetworkInterface` for remote store resolution
- **Access Control**: Three configurable access levels:
  - `"entity"` (default): Only computers on the same entity
  - `"faction"`: Any computer in the same faction
  - `"public"`: Any computer
- **Documentation**: Comprehensive API documentation with examples for both local and remote access patterns

## Implementation Details

- Store data is backed by the existing `SharedDataStore` system using persistent UUIDs
- Block removal automatically unregisters the store and deletes its backing data
- Registry is loaded at server startup and persisted on changes
- Names are case-insensitive, globally unique, and validated (1-64 chars, alphanumeric + hyphens/underscores)
- Access checks enforce the configured level at both local and remote access points
- Integrates with existing `SystemModule` infrastructure for entity-level state management

https://claude.ai/code/session_01Tzs8JrBypjTwmCFpdtLCrA